### PR TITLE
Safely store credentials using keyring

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,15 @@
+v0.7.0
+======
+
+#1: Passwords are no longer stored in or retrieved from the cache
+file. Instead, credentials must be supplied on the command line
+or loaded from `keyring <https://pypi.org/project/keyring>`_.
+This approach allows the passwords to be stored in a secure,
+encrypted, system store. To avoid requiring a username on
+each invocation, the default username is loaded from the
+ABODE_USERNAME environment variable. If the password is not
+present, the user will be prompted for it on the first invocation.
+
 v0.5.2
 ======
 

--- a/README.rst
+++ b/README.rst
@@ -76,21 +76,32 @@ Simple command line implementation arguments::
         --debug               Enable debug logging
         --quiet               Output only warnings and errors
 
-You can get the current alarm mode::
+First invocation, simply log in::
 
-    $ abode -u USERNAME -p PASSWORD --mode
+    $ abode --username happy-customer@example.com
+    Password for happy-customer@example.com:
+2022-10-18 20:30:18 INFO (MainThread) [jaraco.abode] Updating all devices...
+2022-10-18 20:30:18 INFO (MainThread) [jaraco.abode] Login successful
+2022-10-18 20:30:19 INFO (MainThread) [jaraco.abode] Logout successful
+
+Pass ``--username`` with each invocation or set the environment variable
+``ABODE_USERNAME`` in the environment.
+
+Get the current alarm mode::
+
+    $ abode --mode
     
       Mode: standby
     
-To set the alarm mode, one of 'standby', 'home', or 'away'::
+Set the alarm mode to one of 'standby', 'home', or 'away'::
 
-    $ abode -u USERNAME -p PASSWORD --arm home
+    $ abode --arm home
     
       Mode set to: home
 
-A full list of devices and their current states::
+List all devices and their current states::
 
-    $ abode -u USERNAME -p PASSWORD --devices
+    $ abode --devices
     
       Device Name: Glass Break Sensor, Device ID: RF:xxxxxxxx, Device Type: GLASS, Device Status: Online
       Device Name: Keypad, Device ID: RF:xxxxxxxx, Device Type: Keypad, Device Status: Online
@@ -105,29 +116,29 @@ A full list of devices and their current states::
       Device Name: Garage Door Deadbolt, Device ID: ZW:xxxxxxxx, Device Type: Door Lock, Device Status: LockClosed
       Device Name: Alarm area_1, Device ID: area_1, Device Type: Alarm, Device Status: standby
 
-The current state of a specific device using the device id::
+Query the current state of a specific device using the device id::
 
-    $ abode -u USERNAME -p PASSWORD --device ZW:xxxxxxxx
+    $ abode --device ZW:xxxxxxxx
     
       Device Name: Garage Door Deadbolt, Device ID: ZW:xxxxxxxx, Device Type: Door Lock, Device Status: LockClosed
 
-Additionally, multiple specific devices using the device id::
+Query multiple specific devices by device id::
     
-    $ abode -u USERNAME -p PASSWORD --device ZW:xxxxxxxx --device RF:xxxxxxxx
+    $ abode --device ZW:xxxxxxxx --device RF:xxxxxxxx
     
       Device Name: Garage Door Deadbolt, Device ID: ZW:xxxxxxxx, Device Type: Door Lock, Device Status: LockClosed
       Device Name: Back Door, Device ID: RF:xxxxxxxx, Device Type: Door Contact, Device Status: Closed
     
-You can switch a device on or off, or lock and unlock a device by passing multiple arguments::
+Switch a device on or off, or lock and unlock a device by passing multiple arguments::
 
-    $ abode -u USERNAME -p PASSWORD --lock ZW:xxxxxxxx --switchOn ZW:xxxxxxxx
+    $ abode --lock ZW:xxxxxxxx --switchOn ZW:xxxxxxxx
     
       Locked device with id: ZW:xxxxxxxx
       Switched on device with id: ZW:xxxxxxxx
    
-You can also block and listen for all mode and change events as they occur::
+Block and listen for all mode and change events as they occur::
 
-    $ abode -u USERNAME -p PASSWORD --listen
+    $ abode --listen
     
       No devices specified, adding all devices to listener...
       Listening for device updates...
@@ -145,7 +156,7 @@ Keyboard interrupt (CTRL+C) to exit listening mode.
 
 To obtain a list of automations::
 
-    $ abode -u USERNAME -p PASSWORD --automations
+    $ abode --automations
     
       Deadbolts Lock Home (ID: 6) - status - active
       Auto Home (ID: 3) - location - active
@@ -157,13 +168,13 @@ To obtain a list of automations::
       
 To activate or deactivate an automation::
 
-    $ abode -u USERNAME -p PASSWORD --activate 1
+    $ abode --activate 1
     
       Activated automation with id: 1
       
 To trigger a manual (quick) automation::
 
-    $ abode -u USERNAME -p PASSWORD --trigger 7
+    $ abode --trigger 7
     
       Triggered automation with id: 1
 
@@ -172,7 +183,7 @@ Settings
 
 Change settings either using abode.set_setting(setting, value) or through the command line::
 
-  $ abode -u USERNAME -p PASSWORD --set beeper_mute=1
+  $ abode --set beeper_mute=1
   
     Setting beeper_mute changed to 1
 

--- a/README.rst
+++ b/README.rst
@@ -34,55 +34,57 @@ API calls faster than 60 seconds is not recommended as it can overwhelm Abode's 
   
 Command Line Usage
 ==================
+
 Simple command line implementation arguments::
 
     $ abode --help
-      usage: jaraco.abode: Command Line Utility [-h] -u USERNAME -p PASSWORD [--mode]
-                                           [--arm mode] [--set setting=value]
-                                           [--devices] [--device device_id]
-                                           [--json device_id] [--on device_id]
-                                           [--off device_id] [--lock device_id]
-                                           [--unlock device_id] [--automations]
-                                           [--activate automation_id]
-                                           [--deactivate automation_id]
-                                           [--trigger automation_id] [--listen]
-                                           [--debug] [--quiet]
-      
-      optional arguments:
-        -h, --help            show this help message and exit
-        -u USERNAME, --username USERNAME
-                              Username
-        -p PASSWORD, --password PASSWORD
-                              Password
-        --mode                Output current alarm mode
-        --arm mode            Arm alarm to mode
-        --set setting=value   Set setting to a value
-        --devices             Output all devices
-        --device device_id    Output one device for device_id
-        --json device_id      Output the json for device_id
-        --on device_id        Switch on a given device_id
-        --off device_id       Switch off a given device_id
-        --lock device_id      Lock a given device_id
-        --unlock device_id    Unlock a given device_id
-        --automations         Output all automations
-        --activate automation_id
-                              Activate (enable) an automation by  automation_id
-        --deactivate automation_id
-                              Deactivate (disable) an automation by automation_id
-        --trigger automation_id
-                              Trigger (apply) an automation (manual quick-action) by
-                              automation_id
-        --listen              Block and listen for device_id
-        --debug               Enable debug logging
-        --quiet               Output only warnings and errors
+    usage: abode [-h] [-u USERNAME] [-p PASSWORD] [--mfa MFA] [--cache pickle_file]
+                 [--mode] [--arm mode] [--set setting=value] [--devices]
+                 [--device device_id] [--json device_id] [--on device_id] [--off device_id]
+                 [--lock device_id] [--unlock device_id] [--automations]
+                 [--activate automation_id] [--deactivate automation_id]
+                 [--trigger automation_id] [--capture device_id]
+                 [--image device_id=location/image.jpg] [--listen] [--debug] [--quiet]
+
+    options:
+      -h, --help            show this help message and exit
+      -u USERNAME, --username USERNAME
+                            Username
+      -p PASSWORD, --password PASSWORD
+                            Password
+      --mfa MFA             Multifactor authentication code
+      --cache pickle_file   Create/update/use a pickle cache for the username and password.
+      --mode                Output current alarm mode
+      --arm mode            Arm alarm to mode
+      --set setting=value   Set setting to a value
+      --devices             Output all devices
+      --device device_id    Output one device for device_id
+      --json device_id      Output the json for device_id
+      --on device_id        Switch on a given device_id
+      --off device_id       Switch off a given device_id
+      --lock device_id      Lock a given device_id
+      --unlock device_id    Unlock a given device_id
+      --automations         Output all automations
+      --activate automation_id
+                            Activate (enable) an automation by automation_id
+      --deactivate automation_id
+                            Deactivate (disable) an automation by automation_id
+      --trigger automation_id
+                            Trigger (apply) a manual (quick) automation by automation_id
+      --capture device_id   Trigger a new image capture for the given device_id
+      --image device_id=location/image.jpg
+                            Save an image from a camera (if available) to the given path
+      --listen              Block and listen for device_id
+      --debug               Enable debug logging
+      --quiet               Output only warnings and errors
 
 First invocation, simply log in::
 
     $ abode --username happy-customer@example.com
     Password for happy-customer@example.com:
-2022-10-18 20:30:18 INFO (MainThread) [jaraco.abode] Updating all devices...
-2022-10-18 20:30:18 INFO (MainThread) [jaraco.abode] Login successful
-2022-10-18 20:30:19 INFO (MainThread) [jaraco.abode] Logout successful
+    2022-10-18 20:30:18 INFO (MainThread) [jaraco.abode] Updating all devices...
+    2022-10-18 20:30:18 INFO (MainThread) [jaraco.abode] Login successful
+    2022-10-18 20:30:19 INFO (MainThread) [jaraco.abode] Logout successful
 
 Pass ``--username`` with each invocation or set the environment variable
 ``ABODE_USERNAME`` in the environment.

--- a/jaraco/abode/cli.py
+++ b/jaraco/abode/cli.py
@@ -60,7 +60,7 @@ def build_parser():
 
     >>> parser = build_parser()
     """
-    parser = argparse.ArgumentParser("jaraco.abode: Command Line Utility")
+    parser = argparse.ArgumentParser("abode")
 
     parser.add_argument(
         '-u', '--username', help='Username', default=os.environ.get('ABODE_USERNAME')

--- a/jaraco/abode/cli.py
+++ b/jaraco/abode/cli.py
@@ -1,10 +1,14 @@
 """Command-line interface."""
 
+import os
 import json
 import logging
 import time
 import argparse
 import contextlib
+import getpass
+
+import keyring
 
 from . import Abode
 from .helpers import constants as CONST
@@ -58,7 +62,9 @@ def build_parser():
     """
     parser = argparse.ArgumentParser("jaraco.abode: Command Line Utility")
 
-    parser.add_argument('-u', '--username', help='Username')
+    parser.add_argument(
+        '-u', '--username', help='Username', default=os.environ.get('ABODE_USERNAME')
+    )
 
     parser.add_argument('-p', '--password', help='Password')
 
@@ -466,9 +472,24 @@ class Dispatcher:
             _LOGGER.info("Device update listening stopped.")
 
 
+def _get_password(args):
+    if not args.username:
+        raise SystemExit("Username unknown. Pass a username or set ABODE_USERNAME.")
+    args.password = args.password or _get_or_set_password(args.username)
+
+
+def _get_or_set_password(username):
+    password = keyring.get_password(CONST.BASE_URL, username)
+    if not password:
+        password = getpass.getpass(f"Password for {username}: ")
+        keyring.set_password(CONST.BASE_URL, username, password)
+    return password
+
+
 def main():
     """Execute command line helper."""
     args = build_parser().parse_args()
+    _get_password(args)
 
     setup_logging(log_level=logging.INFO + 10 * (args.quiet - args.debug))
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ install_requires =
 	requests >= 2.12.4
 	lomond >= 0.3.3
 	colorlog >= 3.0.1
+	keyring
 
 [options.packages.find]
 exclude =

--- a/tests/test_abode.py
+++ b/tests/test_abode.py
@@ -50,9 +50,9 @@ class TestAbode:
     def tests_initialization(self):
         """Verify we can initialize abode."""
         # pylint: disable=protected-access
-        assert self.abode._cache[CONST.ID] == USERNAME
+        assert self.abode._username == USERNAME
         # pylint: disable=protected-access
-        assert self.abode._cache[CONST.PASSWORD] == PASSWORD
+        assert self.abode._password == PASSWORD
 
     def tests_no_credentials(self):
         """Check that we throw an exception when no username/password."""
@@ -60,7 +60,7 @@ class TestAbode:
             self.abode_no_cred.login()
 
         # pylint: disable=protected-access
-        self.abode_no_cred._cache[CONST.ID] = USERNAME
+        self.abode_no_cred._username = USERNAME
         with pytest.raises(jaraco.abode.AbodeAuthenticationException):
             self.abode_no_cred.login()
 
@@ -71,22 +71,12 @@ class TestAbode:
 
         self.abode_no_cred.login(username=USERNAME, password=PASSWORD)
 
-        # pylint: disable=protected-access
-        assert self.abode_no_cred._cache[CONST.ID] == USERNAME
-        # pylint: disable=protected-access
-        assert self.abode_no_cred._cache[CONST.PASSWORD] == PASSWORD
-
     def tests_manual_login_with_mfa(self, m):
         """Check that we can login with MFA code."""
         m.post(CONST.LOGIN_URL, text=LOGIN.post_response_ok())
         m.get(CONST.OAUTH_TOKEN_URL, text=OAUTH_CLAIMS.get_response_ok())
 
         self.abode_no_cred.login(username=USERNAME, password=PASSWORD, mfa_code=654321)
-
-        # pylint: disable=protected-access
-        assert self.abode_no_cred._cache[CONST.ID] == USERNAME
-        # pylint: disable=protected-access
-        assert self.abode_no_cred._cache[CONST.PASSWORD] == PASSWORD
 
     def tests_auto_login(self, m):
         """Test that automatic login works."""
@@ -109,8 +99,8 @@ class TestAbode:
         )
 
         # pylint: disable=W0212
-        assert abode._cache[CONST.ID] == 'fizz'
-        assert abode._cache[CONST.PASSWORD] == 'buzz'
+        assert abode._username == 'fizz'
+        assert abode._password == 'buzz'
         assert abode._token == MOCK.AUTH_TOKEN
         assert abode._panel == json.loads(panel_json)
         assert abode._user == json.loads(user_json)
@@ -145,8 +135,8 @@ class TestAbode:
         )
 
         # pylint: disable=W0212
-        assert abode._cache[CONST.ID] == 'fizz'
-        assert abode._cache[CONST.PASSWORD] == 'buzz'
+        assert abode._username == 'fizz'
+        assert abode._password == 'buzz'
         assert abode._token == MOCK.AUTH_TOKEN
         assert abode._user == json.loads(user_json)
         assert abode._panel is not None
@@ -255,8 +245,8 @@ class TestAbode:
         original_session = self.abode._session
 
         # pylint: disable=W0212
-        assert self.abode._cache[CONST.ID] == USERNAME
-        assert self.abode._cache[CONST.PASSWORD] == PASSWORD
+        assert self.abode._username == USERNAME
+        assert self.abode._password == PASSWORD
         assert self.abode._token == auth_token
         assert self.abode._user == json.loads(user_json)
         assert self.abode._panel is not None
@@ -565,8 +555,6 @@ class TestAbode:
 
         # Test that our cookies are fully realized prior to login
         # pylint: disable=W0212
-        assert abode._cache['id'] is not None
-        assert abode._cache['password'] is not None
         assert abode._cache['uuid'] is not None
         assert abode._cache['cookies'] is not None
 
@@ -613,8 +601,6 @@ class TestAbode:
 
         # Test that some cache exists
         # pylint: disable=W0212
-        assert empty_abode._cache['id'] is not None
-        assert empty_abode._cache['password'] is not None
         assert empty_abode._cache['uuid'] is not None
 
     @pytest.mark.usefixtures('cache_path')
@@ -641,6 +627,4 @@ class TestAbode:
 
         # Test that some cache exists
         # pylint: disable=W0212
-        assert empty_abode._cache['id'] is not None
-        assert empty_abode._cache['password'] is not None
         assert empty_abode._cache['uuid'] is not None


### PR DESCRIPTION
- No longer are credentials written to or read from the cache. Credentials must be supplied on every invocation. Ref #1.
- Resolve username from ABODE_USERNAME variable. Resolve password from keyring.
- Update changelog
- Update readme to remove excessive username/password parameters.
- Update usage with simply 'abode' and regenerate the usage in README.
