### PR TITLE
Add support for camera snapshots

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+v1.1.0
+======
+
+#8: Added support for camera snapshots.
+
 v1.0.1
 ======
 

--- a/jaraco/abode/helpers/constants.py
+++ b/jaraco/abode/helpers/constants.py
@@ -22,6 +22,7 @@ PARAMS_URL = '/api/v1/devices_beta/'
 PANEL_URL = '/api/v1/panel'
 
 INTEGRATIONS_URL = '/integrations/v1/devices/'
+CAMERA_INTEGRATIONS_URL = '/integrations/v1/camera/'
 
 
 def get_panel_mode_url(area, mode):

--- a/tests/mock/devices/ir_camera.py
+++ b/tests/mock/devices/ir_camera.py
@@ -34,6 +34,7 @@ def device(
         sresp_mode_3='0',
         sresp_entry_3='0',
         sresp_exit_3='0',
+        uuid='1234567890',
         version='852_00.00.03.05TC',
         origin='abode',
         control_url='api/v1/cams/ZB:00000005/capture',


### PR DESCRIPTION
@jaraco, thanks for picking up support for the abandoned abodepy project. This PR is a copy of my previous abodepy PR MisterWil/abodepy#85. It adds support for requesting a camera snapshot image, which does not create an event on the Abode timeline the way that the `capture()` call does. The snapshot can either be stored to a file, similar to a captured image, or returned as a base64-encoded data url. This implementation works for me, but I have only tested it with an Abode Cam 2.