### PR TITLE
Simply store the state on devices

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+v1.2.0
+======
+
+#9: Internal refactoring to store the device state directly and
+reflect it as properties.
+
 v1.1.0
 ======
 

--- a/jaraco/abode/devices/__init__.py
+++ b/jaraco/abode/devices/__init__.py
@@ -18,13 +18,24 @@ class AbodeDevice:
     def __init__(self, state, abode):
         """Set up Abode device."""
         self._state = state
-        self._device_id = state.get('id')
-        self._device_uuid = state.get('uuid')
-        self._name = state.get('name')
-        self._type = state.get('type')
-        self._type_tag = state.get('type_tag')
-        self._generic_type = state.get('generic_type')
         self._abode = abode
+
+    def __getattr__(self, name):
+        if name in '_name _type _type_tag _generic_type'.split():
+            name = name.lstrip('_')
+
+        try:
+            return self._state[name]
+        except KeyError as exc:
+            raise AttributeError(name) from exc
+
+    @property
+    def _device_id(self):
+        return self.id
+
+    @property
+    def _device_uuid(self):
+        return self.uuid
 
     @needs_control_url
     def set_status(self, status):

--- a/jaraco/abode/devices/alarm.py
+++ b/jaraco/abode/devices/alarm.py
@@ -1,5 +1,6 @@
 """Abode alarm device."""
 import logging
+import copy
 
 from ..exceptions import AbodeException
 
@@ -10,16 +11,21 @@ from ..helpers import errors as ERROR
 _LOGGER = logging.getLogger(__name__)
 
 
+def state_from_panel(panel_state, area='1'):
+    """Adapt panel state to alarm state."""
+    alarm_state = copy.deepcopy(panel_state)
+    alarm_state['name'] = CONST.ALARM_NAME
+    alarm_state['id'] = CONST.ALARM_DEVICE_ID + area
+    alarm_state['type'] = CONST.ALARM_TYPE
+    alarm_state['type_tag'] = CONST.DEVICE_ALARM
+    alarm_state['generic_type'] = CONST.TYPE_ALARM
+    alarm_state['uuid'] = alarm_state.get('mac').replace(':', '').lower()
+    return alarm_state
+
+
 def create_alarm(panel_json, abode, area='1'):
     """Create a new alarm device from a panel response."""
-    panel_json['name'] = CONST.ALARM_NAME
-    panel_json['id'] = CONST.ALARM_DEVICE_ID + area
-    panel_json['type'] = CONST.ALARM_TYPE
-    panel_json['type_tag'] = CONST.DEVICE_ALARM
-    panel_json['generic_type'] = CONST.TYPE_ALARM
-    panel_json['uuid'] = panel_json.get('mac').replace(':', '').lower()
-
-    return AbodeAlarm(panel_json, abode, area)
+    return AbodeAlarm(state_from_panel(panel_json), abode, area)
 
 
 class AbodeAlarm(AbodeSwitch):

--- a/jaraco/abode/devices/alarm.py
+++ b/jaraco/abode/devices/alarm.py
@@ -96,6 +96,9 @@ class AbodeAlarm(AbodeSwitch):
 
         return response_object
 
+    def update(self, state):
+        super().update(state_from_panel(state, area=self._area))
+
     @property
     def is_on(self):
         """Is alarm armed."""

--- a/tests/test_alarm.py
+++ b/tests/test_alarm.py
@@ -52,6 +52,7 @@ class TestAlarm:
 
         # Get alarm and test
         alarm = self.abode.get_alarm()
+        assert alarm.device_id == 'area_1'
         assert alarm is not None
         assert alarm.mode == CONST.MODE_STANDBY
         assert alarm.status == CONST.MODE_STANDBY
@@ -72,6 +73,7 @@ class TestAlarm:
         # Refresh alarm and test
         alarm.refresh()
 
+        assert alarm.device_id == 'area_1'
         assert alarm.mode == CONST.MODE_AWAY
         assert alarm.status == CONST.MODE_AWAY
         assert not alarm.battery


### PR DESCRIPTION
- Assert device id
- Extract function for producing alarm state from panel state.
- When updating an alarm (from presumed panel state), adapt the state.
- Store the state just once and derive properties from that state.
