### PR TITLE
Fixing alarm panel refresh when 'mac' is missing

### DIFF
--- a/jaraco/abode/devices/alarm.py
+++ b/jaraco/abode/devices/alarm.py
@@ -23,7 +23,10 @@ def state_from_panel(panel_state, area='1'):
     alarm_state['type'] = 'Alarm'
     alarm_state['type_tag'] = CONST.DEVICE_ALARM
     alarm_state['generic_type'] = CONST.TYPE_ALARM
-    alarm_state['uuid'] = alarm_state.get('mac').replace(':', '').lower()
+    if alarm_state.get('mac'):
+        # On refresh the 'mac' key isn't sent down, just leave the existing UUID if it's
+        # not present
+        alarm_state['uuid'] = alarm_state.get('mac').replace(':', '').lower()
     return alarm_state
 
 

--- a/tests/test_alarm.py
+++ b/tests/test_alarm.py
@@ -67,7 +67,7 @@ class TestAlarm:
         m.get(
             urls.PANEL,
             json=PANEL.get_response_ok(
-                mode=CONST.MODE_AWAY, battery=False, is_cellular=False
+                mode=CONST.MODE_AWAY, battery=False, is_cellular=False, mac=None
             ),
         )
 
@@ -80,15 +80,21 @@ class TestAlarm:
         assert not alarm.battery
         assert not alarm.is_cellular
         assert alarm.is_on
+        # assert alarm device id didn't change after refresh, even though we didn't send
+        # mac
+        assert alarm.device_uuid == '01aab3c4d566'
 
         # Change alarm state to final on state and test
-        m.get(urls.PANEL, json=PANEL.get_response_ok(mode=CONST.MODE_HOME))
+        m.get(urls.PANEL, json=PANEL.get_response_ok(mode=CONST.MODE_HOME, mac=None))
 
         # Refresh alarm and test
         alarm.refresh()
         assert alarm.mode == CONST.MODE_HOME
         assert alarm.status == CONST.MODE_HOME
         assert alarm.is_on
+        assert alarm.device_uuid == '01aab3c4d566'
+        # assert alarm device id didn't change after refresh, even though we didn't send
+        # mac
 
     def test_alarm_device_mode_changes(self, m):
         """Test that the abode alarm can change/report modes."""


### PR DESCRIPTION
Addresses https://github.com/jaraco/jaraco.abode/issues/21