### PR TITLE
Resolve UUID from MAC late and on Alarm objects only.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+v3.2.2
+======
+
+#21: Derive UUID from MAC address late and only for Alarm objects.
+
 v3.2.1
 ======
 

--- a/jaraco/abode/devices/alarm.py
+++ b/jaraco/abode/devices/alarm.py
@@ -23,7 +23,6 @@ def state_from_panel(panel_state, area='1'):
     alarm_state['type'] = 'Alarm'
     alarm_state['type_tag'] = CONST.DEVICE_ALARM
     alarm_state['generic_type'] = CONST.TYPE_ALARM
-    alarm_state['uuid'] = alarm_state.get('mac').replace(':', '').lower()
     return alarm_state
 
 
@@ -147,3 +146,7 @@ class Alarm(Switch):
     def mac_address(self):
         """Get the hub mac address."""
         return self._state.get('mac')
+
+    @property
+    def uuid(self):
+        return self.mac.replace(':', '').lower()


### PR DESCRIPTION
Fixes #21.
