### PR TITLE
Restore is_on behavior for specialized BinarySensor subclasses

### DIFF
--- a/jaraco/abode/devices/binary_sensor.py
+++ b/jaraco/abode/devices/binary_sensor.py
@@ -14,6 +14,8 @@ class BinarySensor(base.Device):
 
         Assume offline or open (worst case).
         """
+        if self.type == 'Occupancy':
+            return self.status not in STATUS.ONLINE
         return self.status not in (
             STATUS.OFF,
             STATUS.OFFLINE,
@@ -43,9 +45,7 @@ class Motion(BinarySensor):
 
 
 class Occupancy(BinarySensor):
-    @property
-    def is_on(self):
-        return self.status not in STATUS.ONLINE
+    pass
 
 
 class Door(BinarySensor):

--- a/newsfragments/+890794d5.bugfix.rst
+++ b/newsfragments/+890794d5.bugfix.rst
@@ -1,0 +1,1 @@
+Restored specialized 'is_on' behavior to base BinarySensor for home-assistant/core#121300.

--- a/tests/mock/devices/occupancy.py
+++ b/tests/mock/devices/occupancy.py
@@ -1,0 +1,87 @@
+"""Mock Abode Occupancy Device."""
+
+import jaraco.abode.devices.status as STATUS
+
+DEVICE_ID = 'RF:00000001'
+
+
+def device(
+    devid=DEVICE_ID,
+    has_motion=False,
+    low_battery=False,
+    no_response=False,
+    out_of_order=False,
+    tampered=False,
+    uuid='87a31f855e684b1ab3b87e2d13e72465',
+):
+    """Occupancy sensor mock device."""
+
+    status = [STATUS.ONLINE, "Motion Detected!"][has_motion]
+    statuses = dict(motion=str(int(has_motion)))
+    return dict(
+        id=devid,
+        type_tag='device_type.povs',
+        type='Occupancy',
+        name='Vault motion',
+        area='1',
+        zone='6',
+        sort_order='',
+        is_window='',
+        bypass='0',
+        schar_24hr='0',
+        sresp_24hr="5",
+        sresp_mode_0='0',
+        sresp_entry_0='0',
+        sresp_exit_0='0',
+        group_name="Motion",
+        group_id="1156954",
+        default_group_id="1",
+        sort_id="1",
+        sresp_mode_1='5',
+        sresp_entry_1='4',
+        sresp_exit_1='0',
+        sresp_mode_2='0',
+        sresp_entry_2='0',
+        sresp_exit_2='0',
+        sresp_mode_3='0',
+        sresp_entry_3='0',
+        sresp_exit_3='0',
+        sresp_mode_4='0',
+        sresp_entry_4='0',
+        sresp_exit_4='0',
+        version='0001',
+        origin='abode',
+        has_subscription=None,
+        onboard="0",
+        s2_grnt_keys="",
+        s2_dsk="",
+        s2_propty="",
+        s2_keys_valid="",
+        zwave_secure_protocol="",
+        control_url='',
+        deep_link=None,
+        status_color='#5cb85c',
+        faults={
+            'low_battery': int(low_battery),
+            'tempered': int(tampered),
+            'supervision': 0,
+            'out_of_order': int(out_of_order),
+            'no_response': int(no_response),
+            'jammed': 0,
+            'zwave_fault': 0,
+        },
+        status=status,
+        status_display=status,
+        statuses=statuses,
+        status_ex='',
+        actions=[],
+        status_icons=[],
+        icon='assets/icons/occupancy-sensor.svg',
+        sresp_trigger="0",
+        sresp_restore="0",
+        occupancy_timer="30",
+        sensitivity="4",
+        model="L1",
+        is_motion_sensor=False,
+        uuid=uuid,
+    )

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -13,6 +13,7 @@ from .mock import panel as PANEL
 from .mock.devices import door_contact as DOOR_CONTACT
 from .mock.devices import glass as GLASS
 from .mock.devices import keypad as KEYPAD
+from .mock.devices import occupancy as OCCUPANCY
 from .mock.devices import remote_controller as REMOTE_CONTROLLER
 from .mock.devices import siren as SIREN
 from .mock.devices import status_display as STATUS_DISPLAY
@@ -50,6 +51,7 @@ class TestBinarySensors:
                 low_battery=False,
                 no_response=False,
             ),
+            OCCUPANCY.device(),
             REMOTE_CONTROLLER.device(
                 devid=REMOTE_CONTROLLER.DEVICE_ID,
                 status=STATUS.OFFLINE,
@@ -104,6 +106,11 @@ class TestBinarySensors:
             KEYPAD.device(
                 devid=KEYPAD.DEVICE_ID,
                 status=STATUS.ONLINE,
+                low_battery=True,
+                no_response=True,
+            ),
+            OCCUPANCY.device(
+                has_motion=True,
                 low_battery=True,
                 no_response=True,
             ),


### PR DESCRIPTION
In home-assistant/core#121300, we learned that https://github.com/jaraco/jaraco.abode/commit/d2b69390ed97a006b05879bc6e5db076ca85369f caused a regression for motion sensors. It turns out that `sensor.Sensor` and `Motion` devices also need this behavior (but presumably only when `type=Occupancy`).

This change adds a test and reverts the offending change to restore behavior selectively.

Future bugs and refactorings will deal with the underlying architectural problems that led to this issue, but this change addresses the symptom to get HA users' expectations restored ASAP.