### PR TITLE
Refactor occupancy specialization

### DIFF
--- a/jaraco/abode/client.py
+++ b/jaraco/abode/client.py
@@ -19,7 +19,7 @@ from jaraco.net.http import cookies
 from . import config, settings
 from .automation import Automation
 from .devices import alarm as ALARM
-from .devices.base import Device
+from .devices.base import Device, Unknown
 from .event_controller import EventController
 from .exceptions import AuthenticationException
 from .helpers import errors as ERROR
@@ -212,7 +212,7 @@ class Client:
     def _create_new_device(self, doc):
         device = Device.new(doc, self)
 
-        if not device:
+        if isinstance(device, Unknown):
             log.debug("Skipping unknown device: %s", doc)
             return
 

--- a/jaraco/abode/devices/alarm.py
+++ b/jaraco/abode/devices/alarm.py
@@ -23,7 +23,6 @@ def state_from_panel(panel_state, area='1'):
     alarm_state['id'] = id(area)
     alarm_state['type'] = 'Alarm'
     alarm_state['type_tag'] = 'device_type.alarm'
-    alarm_state['generic_type'] = 'alarm'
     return alarm_state
 
 

--- a/jaraco/abode/devices/base.py
+++ b/jaraco/abode/devices/base.py
@@ -135,8 +135,11 @@ class Device(Stateful):
 
         init_cls = cls.resolve_class(type_tag)
         spec_cls = init_cls.specialize(state)
-        state['generic_type'] = spec_cls.__name__.lower()
         return spec_cls(state, client)
+
+    @property
+    def generic_type(self):
+        return self.__class__.__name__.lower()
 
     @classmethod
     def by_type(cls):

--- a/jaraco/abode/devices/base.py
+++ b/jaraco/abode/devices/base.py
@@ -133,9 +133,9 @@ class Device(Stateful):
         except KeyError as exc:
             raise jaraco.abode.Exception(ERROR.UNABLE_TO_MAP_DEVICE) from exc
 
-        state['generic_type'] = cls.get_generic_type(type_tag)
-        init_cls = cls.by_type().get(state['generic_type'], Unknown)
+        init_cls = cls.resolve_class(type_tag)
         spec_cls = init_cls.specialize(state)
+        state['generic_type'] = spec_cls.__name__.lower()
         return spec_cls(state, client)
 
     @classmethod
@@ -143,13 +143,13 @@ class Device(Stateful):
         return {sub_cls.__name__.lower(): sub_cls for sub_cls in iter_subclasses(cls)}
 
     @classmethod
-    def get_generic_type(cls, type_tag):
+    def resolve_class(cls, type_tag):
         lookup = {
-            f'device_type.{tag}': sub_cls.__name__.lower()
+            f'device_type.{tag}': sub_cls
             for sub_cls in iter_subclasses(cls)
             for tag in sub_cls.tags
         }
-        return lookup.get(type_tag.lower())
+        return lookup.get(type_tag.lower(), Unknown)
 
     @classmethod
     def specialize(cls, state):

--- a/jaraco/abode/devices/base.py
+++ b/jaraco/abode/devices/base.py
@@ -133,9 +133,7 @@ class Device(Stateful):
         except KeyError as exc:
             raise jaraco.abode.Exception(ERROR.UNABLE_TO_MAP_DEVICE) from exc
 
-        init_cls = cls.resolve_class(type_tag)
-        spec_cls = init_cls.specialize(state)
-        return spec_cls(state, client)
+        return cls.resolve_class(type_tag).specialize(state)(state, client)
 
     @property
     def generic_type(self):

--- a/jaraco/abode/devices/base.py
+++ b/jaraco/abode/devices/base.py
@@ -17,6 +17,11 @@ class Device(Stateful):
     """Class to represent each Abode device."""
 
     tags: Tuple[str, ...] = ()
+    """
+    Each device has a ``type_tag``, something like "device_type.door_lock".
+    Each Device subclass declares the tags that it services (with the
+    "device_type." prefix omitted).
+    """
     _desc_t = '{name} (ID: {id}, UUID: {uuid}) - {type} - {status}'
     _url_t = urls.DEVICE
 

--- a/jaraco/abode/devices/binary_sensor.py
+++ b/jaraco/abode/devices/binary_sensor.py
@@ -37,7 +37,30 @@ class Connectivity(BinarySensor):
 
 
 class Motion(BinarySensor):
-    pass
+    # These device types are all considered 'occupancy' but could apparently
+    # also be multi-sensors based on their state.
+    tags = (
+        'room_sensor',
+        'temperature_sensor',
+        # LM = LIGHT MOTION?
+        'lm',
+        'pir',
+        'povs',
+    )
+
+    @classmethod
+    def specialize(cls, state):
+        from . import sensor
+
+        new_type = (
+            sensor.Sensor
+            if sensor.Sensor.is_sensor(state)
+            else Occupancy
+            if state.get('version', '').startswith('MINIPIR')
+            else cls
+        )
+        state['generic_type'] = new_type.__name__.lower()
+        return new_type
 
 
 class Occupancy(BinarySensor):

--- a/jaraco/abode/devices/binary_sensor.py
+++ b/jaraco/abode/devices/binary_sensor.py
@@ -36,10 +36,6 @@ class Connectivity(BinarySensor):
     )
 
 
-class Moisture(BinarySensor):
-    pass
-
-
 class Motion(BinarySensor):
     pass
 

--- a/jaraco/abode/devices/binary_sensor.py
+++ b/jaraco/abode/devices/binary_sensor.py
@@ -52,9 +52,7 @@ class Motion(BinarySensor):
     def specialize(cls, state):
         from . import sensor
 
-        new_type = sensor.Sensor if sensor.Sensor.is_sensor(state) else cls
-        state['generic_type'] = new_type.__name__.lower()
-        return new_type
+        return sensor.Sensor if sensor.Sensor.is_sensor(state) else cls
 
 
 class Door(BinarySensor):

--- a/jaraco/abode/devices/binary_sensor.py
+++ b/jaraco/abode/devices/binary_sensor.py
@@ -52,19 +52,9 @@ class Motion(BinarySensor):
     def specialize(cls, state):
         from . import sensor
 
-        new_type = (
-            sensor.Sensor
-            if sensor.Sensor.is_sensor(state)
-            else Occupancy
-            if state.get('version', '').startswith('MINIPIR')
-            else cls
-        )
+        new_type = sensor.Sensor if sensor.Sensor.is_sensor(state) else cls
         state['generic_type'] = new_type.__name__.lower()
         return new_type
-
-
-class Occupancy(BinarySensor):
-    pass
 
 
 class Door(BinarySensor):

--- a/newsfragments/28.feature.rst
+++ b/newsfragments/28.feature.rst
@@ -1,0 +1,1 @@
+Refactored sensor specialization.

--- a/tests/mock/devices/valve.py
+++ b/tests/mock/devices/valve.py
@@ -25,7 +25,6 @@ def device(devid=DEVICE_ID, status=STATUS.OPEN, low_battery=False, no_response=F
             'out_of_order': 0,
             'no_response': int(no_response),
         },
-        generic_type='valve',
         group_id='xxxxx',
         group_name='Water leak',
         has_subscription=None,


### PR DESCRIPTION
- **Remove Moisture class, unused.**
- **Refactored sensor specialization.**
- **Removed Occupancy class.**
- **Avoid indirection through 'generic_type' when resolving a Device subclass.**
- **Reflect the generic_type from the class instead of manifesting it in the state.**
- **Inline the initialization.**
- **Add a docstring explaining `Device.tags`.**
