### PR TITLE
Simplify the lm structure

### DIFF
--- a/jaraco/abode/devices/base.py
+++ b/jaraco/abode/devices/base.py
@@ -138,7 +138,7 @@ class Device(Stateful):
         except KeyError as exc:
             raise jaraco.abode.Exception(ERROR.UNABLE_TO_MAP_DEVICE) from exc
 
-        return cls.resolve_class(type_tag).specialize(state)(state, client)
+        return cls.resolve_class(type_tag)(state, client)
 
     @property
     def generic_type(self):
@@ -160,10 +160,6 @@ class Device(Stateful):
             for tag in sub_cls.tags
         }
         return lookup.get(type_tag.lower(), Unknown)
-
-    @classmethod
-    def specialize(cls, state):
-        return cls
 
 
 class Unknown(Device):

--- a/jaraco/abode/devices/binary_sensor.py
+++ b/jaraco/abode/devices/binary_sensor.py
@@ -37,8 +37,6 @@ class Connectivity(BinarySensor):
 
 
 class Motion(BinarySensor):
-    # These device types are all considered 'occupancy' but could apparently
-    # also be multi-sensors based on their state.
     tags = (
         'room_sensor',
         'temperature_sensor',

--- a/jaraco/abode/devices/binary_sensor.py
+++ b/jaraco/abode/devices/binary_sensor.py
@@ -42,17 +42,9 @@ class Motion(BinarySensor):
     tags = (
         'room_sensor',
         'temperature_sensor',
-        # LM = LIGHT MOTION?
-        'lm',
         'pir',
         'povs',
     )
-
-    @classmethod
-    def specialize(cls, state):
-        from . import sensor
-
-        return sensor.Sensor if sensor.Sensor.is_sensor(state) else cls
 
 
 class Door(BinarySensor):

--- a/jaraco/abode/devices/binary_sensor.py
+++ b/jaraco/abode/devices/binary_sensor.py
@@ -38,8 +38,6 @@ class Connectivity(BinarySensor):
 
 class Motion(BinarySensor):
     tags = (
-        'room_sensor',
-        'temperature_sensor',
         'pir',
         'povs',
     )

--- a/jaraco/abode/devices/binary_sensor.py
+++ b/jaraco/abode/devices/binary_sensor.py
@@ -14,8 +14,6 @@ class BinarySensor(base.Device):
 
         Assume offline or open (worst case).
         """
-        if self.type == 'Occupancy':
-            return self.status not in STATUS.ONLINE
         return self.status not in (
             STATUS.OFF,
             STATUS.OFFLINE,
@@ -41,6 +39,12 @@ class Motion(BinarySensor):
         'pir',
         'povs',
     )
+
+    @property
+    def is_on(self):
+        if self.type == 'Occupancy':
+            return self.status not in STATUS.ONLINE
+        return super().is_on
 
 
 class Door(BinarySensor):

--- a/jaraco/abode/devices/sensor.py
+++ b/jaraco/abode/devices/sensor.py
@@ -2,10 +2,10 @@
 
 import re
 
-from .binary_sensor import BinarySensor
+from . import base
 
 
-class Sensor(BinarySensor):
+class Sensor(base.Device):
     """Class to represent a sensor device."""
 
     tags = ('lm',)

--- a/jaraco/abode/devices/sensor.py
+++ b/jaraco/abode/devices/sensor.py
@@ -8,12 +8,7 @@ from .binary_sensor import BinarySensor
 class Sensor(BinarySensor):
     """Class to represent a sensor device."""
 
-    keys = {'temperature', 'humidity', 'lux'}
-
-    @classmethod
-    def is_sensor(cls, state):
-        statuses = state.get('statuses', {})
-        return any(key in statuses for key in cls.keys)
+    tags = ('lm',)
 
     def _get_status(self, key):
         return self._state.get('statuses', {}).get(key)

--- a/newsfragments/+fd932167.removal.rst
+++ b/newsfragments/+fd932167.removal.rst
@@ -1,0 +1,1 @@
+Substantial refactoring and simplification around the BinarySensor classes and subclasses. Support for 'room_sensor' and 'temperature_sensor' were removed since there is no evidence they were ever needed. Only 'lm' sensors are considered multi-sensors (with temperature and humidity). It's conceivable these changes will break some existing cases. Please report any issues.

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -15,6 +15,7 @@ from .mock.devices import door_contact as DOOR_CONTACT
 from .mock.devices import glass as GLASS
 from .mock.devices import keypad as KEYPAD
 from .mock.devices import occupancy as OCCUPANCY
+from .mock.devices import pir as PIR
 from .mock.devices import remote_controller as REMOTE_CONTROLLER
 from .mock.devices import siren as SIREN
 from .mock.devices import status_display as STATUS_DISPLAY
@@ -42,6 +43,9 @@ class TestBinarySensors:
                 status=STATUS.OFFLINE,
             ),
             OCCUPANCY.device(),
+            PIR.device(
+                status=STATUS.OFFLINE,
+            ),
             REMOTE_CONTROLLER.device(
                 status=STATUS.OFFLINE,
             ),
@@ -82,6 +86,10 @@ class TestBinarySensors:
             ),
             OCCUPANCY.device(
                 has_motion=True,
+                low_battery=True,
+                no_response=True,
+            ),
+            PIR.device(
                 low_battery=True,
                 no_response=True,
             ),


### PR DESCRIPTION
- **Simply resolve the 'device_type.lm' to the 'Sensor' and avoid the 'specialize()' rigamarol.**
- **Derive Sensor from base.Device since is_on is not used.**
- **Remove comment that doesn't correspond to what's observed.**
- **Remove temperature_sensor and room_sensor, as they're uncovered by tests.**
- **Include pir in the binary_sensor tests.**
- **Move 'Occupancy' special case to the Motion class.**
- **Add news fragment.**
