### PR TITLE
Add manual alarm triggers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,10 @@ Simple command line implementation arguments::
                  [--lock device_id] [--unlock device_id] [--automations]
                  [--activate automation_id] [--deactivate automation_id]
                  [--trigger automation_id] [--capture device_id] [--stream device_id]
-                 [--image device_id=location/image.jpg] [--listen] [--debug] [--quiet]
+                 [--image device_id=location/image.jpg] [--trigger-alarm type]
+                 [--acknowledge-event timeline_id] [--dismiss-event timeline_id]
+                 [--test-mode-status] [--test-mode-enable] [--test-mode-disable]
+                 [--listen] [--debug] [--quiet]
 
     options:
       -h, --help            show this help message and exit
@@ -72,6 +75,14 @@ Simple command line implementation arguments::
       --stream device_id    Start a new KVS video stream for the given device_id
       --image device_id=location/image.jpg
                             Save an image from a camera (if available) to the given path
+      --trigger-alarm type  Trigger a manual alarm by type (PANIC, SILENT_PANIC, MEDICAL, CO, SMOKE_CO, SMOKE, BURGLAR)
+      --acknowledge-event timeline_id
+                            Acknowledge a timeline event by timeline_id
+      --dismiss-event timeline_id
+                            Dismiss a timeline event by timeline_id
+      --test-mode-status    Output the current test mode status
+      --test-mode-enable    Enable test mode (alarms will not be dispatched to monitoring service)
+      --test-mode-disable   Disable test mode
       --listen              Block and listen for device_id
       --debug               Enable debug logging
       --quiet               Output only warnings and errors
@@ -175,8 +186,87 @@ To activate or deactivate an automation::
 To trigger a manual (quick) automation::
 
     $ abode --trigger 7
-    
+
       Triggered automation with id: 1
+
+Trigger a Manual Alarm
+======================
+
+Trigger a manual alarm by type (useful for testing or emergency scenarios)::
+
+    $ abode --trigger-alarm PANIC
+
+      Triggered manual alarm of type: PANIC
+
+Available alarm types::
+
+    PANIC         - Panic alarm
+    SILENT_PANIC  - Silent panic alarm
+    MEDICAL       - Medical emergency
+    CO            - Carbon monoxide
+    SMOKE_CO      - Smoke and carbon monoxide
+    SMOKE         - Smoke alarm
+    BURGLAR       - Burglar/intrusion alarm
+
+Timeline Events
+===============
+
+Acknowledge a timeline event after it has been triggered::
+
+    $ abode --acknowledge-event 12345
+
+      Acknowledged timeline event: 12345
+
+Dismiss (ignore) a timeline event::
+
+    $ abode --dismiss-event 12345
+
+      Dismissed timeline event: 12345
+
+Test Mode
+=========
+
+Test mode allows you to test your alarm system without dispatching alerts to the monitoring service. When enabled, any triggered alarms will not be sent to emergency services. Test mode automatically turns off after 30 minutes.
+
+Check the current test mode status::
+
+    $ abode --test-mode-status
+
+      Test mode is currently: disabled
+
+Enable test mode::
+
+    $ abode --test-mode-enable
+
+      Test mode enabled (automatically turns off after 30 minutes)
+
+Disable test mode::
+
+    $ abode --test-mode-disable
+
+      Test mode disabled
+
+**Python API Usage**
+
+You can also control test mode programmatically::
+
+    import jaraco.abode
+
+    # Initialize the client
+    client = jaraco.abode.Client(username='your@email.com', password='your_password')
+    client.login()
+
+    # Check test mode status
+    is_test_mode = client.get_test_mode()
+    print(f"Test mode is: {'enabled' if is_test_mode else 'disabled'}")
+
+    # Enable test mode
+    result = client.set_test_mode(True)
+    print("Test mode enabled")
+
+    # Disable test mode
+    result = client.set_test_mode(False)
+    print("Test mode disabled")
 
 Settings
 ========

--- a/jaraco/abode/devices/alarm.py
+++ b/jaraco/abode/devices/alarm.py
@@ -1,7 +1,9 @@
 """Abode alarm device."""
 
 import copy
+import json
 import logging
+import time
 
 import jaraco.abode
 
@@ -36,6 +38,8 @@ class Alarm(Switch):
 
     tags = ('alarm',)
     all_modes = 'away', 'standby', 'home'
+    all_alarm_types = 'PANIC', 'SILENT_PANIC', 'MEDICAL', 'CO', 'SMOKE_CO', 'SMOKE', 'BURGLAR'
+    timeline_event_retry_delays = (0, 2, 5, 10, 20, 30)  # Exponential backoff in seconds
 
     def __init__(self, json_obj, abode, area='1'):
         """Set up Abode alarm device."""
@@ -82,6 +86,100 @@ class Alarm(Switch):
     def set_standby(self):
         """Arm Abode to stay mode."""
         return self.set_mode('standby')
+
+    def trigger_manual_alarm(self, alarm_type):
+        """Trigger a manual alarm and fetch the corresponding timeline event ID."""
+        if not alarm_type:
+            raise jaraco.abode.Exception(ERROR.MISSING_ALARM_TYPE)
+
+        alarm_type = alarm_type.upper()
+
+        if alarm_type not in self.all_alarm_types:
+            raise jaraco.abode.Exception(ERROR.INVALID_ALARM_TYPE)
+
+        response = self._client.send_request(
+            'post', urls.panel_alarm(), data={'type': alarm_type}
+        )
+
+        log.debug('Trigger Manual Alarm URL (post): %s', urls.panel_alarm())
+        log.debug('Trigger Manual Alarm Response (raw): %s', response.text)
+
+        response_object = response.json()
+
+        # Print full payload for debugging
+        log.debug(
+            'Trigger Manual Alarm Response:\n%s',
+            json.dumps(response_object, indent=2),
+        )
+
+        # Check for successful response
+        if response_object.get('code') != 200:
+            raise jaraco.abode.Exception(ERROR.TRIGGER_ALARM_RESPONSE)
+
+        log.info('Triggered manual alarm %s of type: %s', self.id, alarm_type)
+
+        # Fetch timeline events to find the alarm event ID
+        event_id = self._find_timeline_alarm_event()
+
+        if event_id:
+            response_object['event_id'] = event_id
+            log.info('Found alarm event ID: %s', event_id)
+        else:
+            log.warning('Could not find timeline event for triggered alarm')
+
+        return response_object
+
+    def _find_timeline_alarm_event(self, timeout_seconds=90):
+        """Find the most recent alarm event within the timeout window.
+
+        Looks for the most recent event with is_alarm='1' that occurred
+        within the timeout window. Uses exponential backoff to retry because
+        Abode's API does not immediately expose triggered alarm events in
+        the timeline (typically 30-60+ seconds delay). This allows us to
+        reliably return the event ID to the caller for dismissal/acknowledgment.
+
+        Args:
+            timeout_seconds: Maximum age of event to consider (in seconds)
+
+        Returns:
+            Event ID if found, None otherwise
+        """
+        try:
+            trigger_time = time.time()
+
+            for delay_seconds in self.timeline_event_retry_delays:
+                if delay_seconds > 0:
+                    log.debug('Event not found, waiting %d seconds before retry', delay_seconds)
+                    time.sleep(delay_seconds)
+
+                # Fetch recent timeline events
+                events = self._client.get_timeline_events(size=10)
+
+                if not events:
+                    log.debug('No timeline events found (attempt %d)', self.timeline_event_retry_delays.index(delay_seconds) + 1)
+                    continue
+
+                # Look for the most recent alarm event within the timeout window
+                for event in events:
+                    # Check if it's an alarm event
+                    if event.get('is_alarm') == '1':
+                        # Verify it's recent (within timeout)
+                        event_utc = int(event.get('event_utc', 0))
+                        age_seconds = trigger_time - event_utc
+
+                        if 0 <= age_seconds <= timeout_seconds:
+                            event_id = event.get('id')
+                            event_type = event.get('event_type', 'Unknown')
+                            log.debug('Found recent alarm event: id=%s, type=%s, age=%.1f seconds',
+                                     event_id, event_type, age_seconds)
+                            return event_id
+
+            log.warning('No recent alarm event found within %d seconds after multiple retries', timeout_seconds)
+            return None
+
+        except Exception as e:
+            log.warning('Error finding timeline alarm event: %s', e)
+            return None
 
     def switch_on(self):
         """Arm Abode to default mode."""

--- a/jaraco/abode/helpers/errors.py
+++ b/jaraco/abode/helpers/errors.py
@@ -87,3 +87,21 @@ MFA_CODE_REQUIRED = (32, "Multifactor authentication code required for login.")
 UNKNOWN_MFA_TYPE = (33, "Unknown multifactor authentication type.")
 
 START_KVS_STREAM = (34, "Unable to start KVS stream for camera")
+
+MISSING_ALARM_TYPE = (35, "No alarm type found or alarm type is empty")
+
+INVALID_ALARM_TYPE = (36, "Alarm type is not a valid alarm type")
+
+TRIGGER_ALARM_RESPONSE = (37, "Manual alarm trigger response did not match expected values")
+
+MISSING_TIMELINE_ID = (38, "Timeline ID must be provided")
+
+INVALID_TIMELINE_ID = (39, "Timeline ID is not valid")
+
+ACK_TIMELINE_RESPONSE = (40, "Timeline acknowledgment response did not match expected values")
+
+INVALID_TEST_MODE_VALUE = (41, "Test mode must be a boolean value")
+
+SET_TEST_MODE_RESPONSE = (42, "Failed to set test mode - unexpected response")
+
+TIMELINE_EVENT_ALREADY_PROCESSED = 1069

--- a/jaraco/abode/helpers/urls.py
+++ b/jaraco/abode/helpers/urls.py
@@ -8,6 +8,8 @@ OAUTH_TOKEN = '/api/auth2/claims'
 PARAMS = '/api/v1/devices_beta/'
 
 PANEL = '/api/v1/panel'
+SECURITY_PANEL = '/integrations/v1/security-panel'
+CMS_SETTINGS = '/integrations/v1/cms/settings'
 
 INTEGRATIONS = '/integrations/v1/devices/'
 CAMERA_INTEGRATIONS = '/integrations/v1/camera/'
@@ -16,6 +18,11 @@ CAMERA_INTEGRATIONS = '/integrations/v1/camera/'
 def panel_mode(area, mode):
     """Create panel URL."""
     return f'/api/v1/panel/mode/{area}/{mode}'
+
+
+def panel_alarm():
+    """Create panel manual alarm URL."""
+    return '/integrations/v1/panel/alarm'
 
 
 DEVICES = '/api/v1/devices'
@@ -31,6 +38,17 @@ AUTOMATION = '/integrations/v1/automations/'
 AUTOMATION_ID = AUTOMATION + '{id}/'
 AUTOMATION_APPLY = AUTOMATION_ID + 'apply'
 
+TIMELINE = '/api/v1/timeline'
 TIMELINE_IMAGES_ID = (
     '/api/v1/timeline?device_id={device_id}&dir=next&event_label=Image+Capture&size=1'
 )
+
+
+def timeline_verify_alarm(timeline_id):
+    """Create timeline verify alarm URL."""
+    return f'/api/v1/timeline/{timeline_id}/verify_alarm'
+
+
+def timeline_ignore_alarm(timeline_id):
+    """Create timeline ignore alarm URL."""
+    return f'/api/v1/timeline/{timeline_id}/ignore_alarm'

--- a/tests/mock/cms.py
+++ b/tests/mock/cms.py
@@ -1,0 +1,46 @@
+"""Mock CMS/Security Panel Responses."""
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def get_security_panel_response(test_mode_active=False) -> Mapping[str, Any]:
+    """Return security panel response json with test mode status."""
+    return {
+        "id": "AA:BB:CC:DD:EE:FF",
+        "siteId": "0123456789abcdef0123456789abcdef",
+        "type": "1",
+        "state": {
+            "panelMode": "STANDBY",
+            "currentAlarms": [],
+            "cellConnected": False,
+            "cellSignalStrength": "9",
+        },
+        "health": {"connectivity": "OK", "faults": []},
+        "attributes": {
+            "home": {"entryTimerInSeconds": 60, "exitTimerInSeconds": 60},
+            "away": {"entryTimerInSeconds": 60, "exitTimerInSeconds": 60},
+            "cms": {
+                "vendorId": 2,
+                "vendor": "rrms",
+                "testModeActive": test_mode_active,
+                "customSettings": True,
+                "monitoringActive": True,
+                "faults": [],
+                "pin": "1234",
+            },
+        },
+    }
+
+
+def post_cms_settings_response(test_mode_active=True) -> Mapping[str, Any]:
+    """Return CMS settings update response json."""
+    return {
+        "monitoringActive": True,
+        "testModeActive": test_mode_active,
+        "sendMedia": True,
+        "dispatchWithoutVerification": True,
+        "dispatchPolice": True,
+        "dispatchFire": True,
+        "dispatchMedical": True,
+    }

--- a/tests/test_test_mode.py
+++ b/tests/test_test_mode.py
@@ -1,0 +1,74 @@
+"""Test test mode functionality."""
+
+import pytest
+
+import jaraco.abode
+from jaraco.abode.helpers import urls
+
+from .mock import cms as CMS
+from .mock import login as LOGIN
+from .mock import oauth_claims as OAUTH_CLAIMS
+
+
+class TestTestMode:
+    """Test the test mode functionality."""
+
+    def test_get_test_mode_disabled(self, m):
+        """Test getting test mode status when disabled."""
+        m.post(urls.LOGIN, json=LOGIN.post_response_ok())
+        m.get(urls.OAUTH_TOKEN, json=OAUTH_CLAIMS.get_response_ok())
+        m.get(urls.SECURITY_PANEL, json=CMS.get_security_panel_response(test_mode_active=False))
+
+        self.client.login()
+        test_mode = self.client.get_test_mode()
+
+        assert test_mode is False
+
+    def test_get_test_mode_enabled(self, m):
+        """Test getting test mode status when enabled."""
+        m.post(urls.LOGIN, json=LOGIN.post_response_ok())
+        m.get(urls.OAUTH_TOKEN, json=OAUTH_CLAIMS.get_response_ok())
+        m.get(urls.SECURITY_PANEL, json=CMS.get_security_panel_response(test_mode_active=True))
+
+        self.client.login()
+        test_mode = self.client.get_test_mode()
+
+        assert test_mode is True
+
+    def test_set_test_mode_enable(self, m):
+        """Test enabling test mode."""
+        m.post(urls.LOGIN, json=LOGIN.post_response_ok())
+        m.get(urls.OAUTH_TOKEN, json=OAUTH_CLAIMS.get_response_ok())
+        m.post(urls.CMS_SETTINGS, json=CMS.post_cms_settings_response(test_mode_active=True))
+
+        self.client.login()
+        result = self.client.set_test_mode(True)
+
+        assert result['testModeActive'] is True
+        assert result['monitoringActive'] is True
+
+    def test_set_test_mode_disable(self, m):
+        """Test disabling test mode."""
+        m.post(urls.LOGIN, json=LOGIN.post_response_ok())
+        m.get(urls.OAUTH_TOKEN, json=OAUTH_CLAIMS.get_response_ok())
+        m.post(urls.CMS_SETTINGS, json=CMS.post_cms_settings_response(test_mode_active=False))
+
+        self.client.login()
+        result = self.client.set_test_mode(False)
+
+        assert result['testModeActive'] is False
+
+    def test_set_test_mode_invalid_type(self, m):
+        """Test that set_test_mode raises exception for non-boolean values."""
+        m.post(urls.LOGIN, json=LOGIN.post_response_ok())
+        m.get(urls.OAUTH_TOKEN, json=OAUTH_CLAIMS.get_response_ok())
+
+        self.client.login()
+
+        with pytest.raises(jaraco.abode.Exception) as exc_info:
+            self.client.set_test_mode("true")
+        assert exc_info.value.message == "Test mode must be a boolean value"
+
+        with pytest.raises(jaraco.abode.Exception) as exc_info:
+            self.client.set_test_mode(1)
+        assert exc_info.value.message == "Test mode must be a boolean value"


### PR DESCRIPTION
- Implement manual alarm trigger endpoint (`/integrations/v1/panel/alarm`)
- Support 7 alarm types: PANIC, SILENT_PANIC, MEDICAL, CO, SMOKE_CO, SMOKE, BURGLAR
- Add timeline event management (acknowledge/dismiss)
- Expose event IDs in trigger response for easier dismissal/ack
  - It uses an exponential backoff to allow Abode servers time to expose the event (0, 2, 5, 10, 20, and 30 seconds)
- Add test mode support for safe testing without dispatch to monitoring service
- Include CLI parameters for all the above features
  - `--trigger-alarm TYPE`: Trigger manual alarm by type
  - `--acknowledge-event EVENT_ID`: Acknowledge timeline event
  - `--dismiss-event EVENT_ID`: Dismiss timeline event
  - `--test-mode-status/enable/disable`: Manage test mode
  
 ---

My main motivation behind this PR is to expose a few more things for Home Assistant (I use Abode and have a bunch of sensors that do not connect with their system).
The Abode mobile app I saw that you can trigger manual alarms and I thought that could be a good workaround for that limitation.
The dismissal/acknowledge of alarms is not super straightforwad. The timeline event id from triggering doesn't come directly when calling the endpoint and it's not immediately available via the timeline so we have to ask for it a few times until it shows up.

During my tests I also find out about `Test Mode` (available through their website) which is perfect for when you are working on some automations, so I decided to leave that option here as well.

<img width="647" height="649" alt="image" src="https://github.com/user-attachments/assets/638cd188-f344-45a0-b644-7dd65b961ae6" />

I've tried to stick to all the conventions and patterns I've seen in the code, hopefully this is good enough!